### PR TITLE
Add OSM Attribution to world- layers

### DIFF
--- a/src/script/plugins/MapBoxSource.js
+++ b/src/script/plugins/MapBoxSource.js
@@ -143,7 +143,9 @@ gxp.plugins.MapBoxSource = Ext.extend(gxp.plugins.LayerSource, {
                     "http://d.tiles.mapbox.com/mapbox/"
                 ],
                 OpenLayers.Util.applyDefaults({
-                    attribution: "<a href='http://mapbox.com'>MapBox</a> | <a href='http://mapbox.com/tos'>Terms of Service</a>",
+                    attribution: /^world/.match(name) ?
+                        "<a href='http://mapbox.com'>MapBox</a> | Some Data &copy; OSM CC-BY-SA | <a href='http://mapbox.com/tos'>Terms of Service</a>" :
+                        "<a href='http://mapbox.com'>MapBox</a> | <a href='http://mapbox.com/tos'>Terms of Service</a>",
                     type: "png",
                     tileOrigin: new OpenLayers.LonLat(-128 * 156543.0339, -128 * 156543.0339),
                     layername: name


### PR DESCRIPTION
I haven't been able to completely test this patch - it looks like the test runners in gxp rely on external dependencies on OpenLayers, and I don't have a lot of time to do a testing setup. However, it's a two-line patch - add mentions of OSM data to layers that start with `world-`. There could be more sophisticated versions of this, but I think it'll cut it and is all we need attribution-wise.
