### PR TITLE
Ensure event handlers are unregistered when panel is destroyed

### DIFF
--- a/src/script/widgets/GoogleEarthPanel.js
+++ b/src/script/widgets/GoogleEarthPanel.js
@@ -159,6 +159,12 @@ gxp.GoogleEarthPanel = Ext.extend(Ext.Panel, {
         this.layers.on("update", this.updateLayers, this);
         
         this.layers.on("add", this.updateLayers, this);
+
+        this.on("destroy", function() {
+            this.layers.un("remove", this.updateLayers, this);
+            this.layers.un("update", this.updateLayers, this);
+            this.layers.un("add", this.updateLayers, this);
+        }, this);
         
         // Set up events. Notice global google namespace.
         // google.earth.addEventListener(this.earth.getView(), 


### PR DESCRIPTION
`GoogleEarthPanel` does not unregister the event handlers it adds on the map's layers. This causes problems later if the map's layers are modified after the `GoogleEarthPanel` is destroyed.

The attached patch fixes this.
