### PR TITLE
GoogleEarthPanel use beforeDestroy method rather than beforedestroy event

### DIFF
--- a/src/script/widgets/GoogleEarthPanel.js
+++ b/src/script/widgets/GoogleEarthPanel.js
@@ -160,12 +160,6 @@ gxp.GoogleEarthPanel = Ext.extend(Ext.Panel, {
         
         this.layers.on("add", this.updateLayers, this);
 
-        this.on("beforedestroy", function() {
-            this.layers.un("remove", this.updateLayers, this);
-            this.layers.un("update", this.updateLayers, this);
-            this.layers.un("add", this.updateLayers, this);
-        }, this);
-        
         this.fireEvent("pluginready", this.earth);
 
         // Set up events. Notice global google namespace.
@@ -209,6 +203,15 @@ gxp.GoogleEarthPanel = Ext.extend(Ext.Panel, {
                 }).createDelegate(this)
             );
         }
+    },
+
+    /**
+     */
+    beforeDestroy: function() {
+        this.layers.un("remove", this.updateLayers, this);
+        this.layers.un("update", this.updateLayers, this);
+        this.layers.un("add", this.updateLayers, this);
+        gxp.GoogleEarthPanel.superclass.beforeDestroy.call(this);
     },
 
     /** private: method[updateLayers]


### PR DESCRIPTION
This patch uses Ext.Component's beforeDestroy method rather than registering an event handler to clean up the event handlers on destruction. It's a cleaner solution than using an event. Thanks to @elemoine.
