### PR TITLE
Cleaning up example use so you can copy and paste a working example...

### DIFF
--- a/src/script/plugins/SelectedFeatureActions.js
+++ b/src/script/plugins/SelectedFeatureActions.js
@@ -33,13 +33,14 @@ Ext.namespace("gxp.plugins");
   *  .. code-block:: javascript
   *
   *    tools: [{
-  *        ptype: "gxp_selectedFeatureActions",
+  *        ptype: "gxp_selectedfeatureactions",
   *        featureManager: "myfeaturemanager",
   *        actionTarget: "featuregrid.contextMenu",
   *        actions: [{
   *            menuText: "Search for title",
   *            urlTemplate: "http://google.com/search?q={title}",
   *            iconCls: "google-icon"
+  *        }]
   *        }
   *        //...
   *    ]


### PR DESCRIPTION
ptype currently has mixed case characters- should be lowercase. Also closed brackets and braces.
