### PR TITLE
Allow for customization of 'other_params' when loading Google API

### DIFF
--- a/src/script/plugins/GoogleSource.js
+++ b/src/script/plugins/GoogleSource.js
@@ -100,6 +100,13 @@ gxp.plugins.GoogleSource = Ext.extend(gxp.plugins.LayerSource, {
      */
     terrainAbstract: "Show street map with terrain",
 
+    /** api: config[otherParams]
+     *  ``String``
+     *  Additional parameters to be sent to Google,
+     *  default is "sensore=false"
+     */
+    otherParams: "sensor=false",
+
     constructor: function(config) {
         this.config = config;
         gxp.plugins.GoogleSource.superclass.constructor.apply(this, arguments);
@@ -111,6 +118,7 @@ gxp.plugins.GoogleSource = Ext.extend(gxp.plugins.LayerSource, {
      */
     createStore: function() {
         gxp.plugins.GoogleSource.loader.onLoad({
+            otherParams: this.otherParams,
             timeout: this.timeout,
             callback: this.syncCreateStore,
             errback: function() {
@@ -308,7 +316,7 @@ gxp.plugins.GoogleSource.loader = new (Ext.extend(Ext.util.Observable, {
                     version: 3.3,
                     nocss: "true",
                     callback: "gxp.plugins.GoogleSource.loader.onScriptLoad",
-                    other_params: "sensor=false"
+                    other_params: options.otherParams
                 }]
             })
         };


### PR DESCRIPTION
If using 'Google Maps API for Business', a client id needs to be sent as a parameter.  There also may be cases where it's desired to set "sensor=true" for mobile web apps.
