### PR TITLE
Print support for TMS and Vector layers "enabled" in Print.js

### DIFF
--- a/src/script/plugins/Print.js
+++ b/src/script/plugins/Print.js
@@ -238,7 +238,9 @@ gxp.plugins.Print = Ext.extend(gxp.plugins.Tool, {
             function isPrintable(layer) {
                 return layer.getVisibility() === true && (
                     layer instanceof OpenLayers.Layer.WMS ||
-                    layer instanceof OpenLayers.Layer.OSM
+                    layer instanceof OpenLayers.Layer.OSM ||
+                    layer instanceof OpenLayers.Layer.TMS ||
+                    layer instanceof OpenLayers.Layer.Vector
                 );
             }
 


### PR DESCRIPTION
added TMS and Vector as valid printable layers to plugins/Print.js

at about Line 241:
            function isPrintable(layer) {
                return layer.getVisibility() === true && (
                    layer instanceof OpenLayers.Layer.WMS ||
                    layer instanceof OpenLayers.Layer.OSM ||
                    layer instanceof OpenLayers.Layer.TMS ||
                    layer instanceof OpenLayers.Layer.Vector 
                );
            }

Yes, I think those layers should be supported, and I just tried them out with Mapfish-print they work fine!
Geoserver has issues with them because they are not using the latest mapfish-print plugin. It crashes because of this (for TMS):
https://github.com/mapfish/mapfish-print/commit/2cee3210800e51495619272935f39c14cecafb7a
