### PR TITLE
google geocoder now requires sensor param

### DIFF
--- a/src/script/plugins/GoogleSource.js
+++ b/src/script/plugins/GoogleSource.js
@@ -103,7 +103,7 @@ gxp.plugins.GoogleSource = Ext.extend(gxp.plugins.LayerSource, {
     /** api: config[otherParams]
      *  ``String``
      *  Additional parameters to be sent to Google,
-     *  default is "sensore=false"
+     *  default is "sensor=false"
      */
     otherParams: "sensor=false",
 

--- a/src/script/widgets/form/GoogleGeocoderComboBox.js
+++ b/src/script/widgets/form/GoogleGeocoderComboBox.js
@@ -70,6 +70,7 @@ gxp.form.GoogleGeocoderComboBox = Ext.extend(Ext.form.ComboBox, {
                 throw new Error("The gxp.form.GoogleGeocoderComboBox requires the gxp.plugins.GoogleSource or the Google Maps V3 API to be loaded.");
             }
             gxp.plugins.GoogleSource.loader.onLoad({
+                otherParams: gxp.plugins.GoogleSource.prototype.otherParams,
                 callback: this.prepGeocoder,
                 errback: function() {
                     throw new Error("The Google Maps script failed to load within the given timeout.");


### PR DESCRIPTION
this pull request fixes the Google Geocoder plugin, it is currently broken because we are not sending the sensor parameter which is required.
