### PR TITLE
add support for using YouTube videos in the annotations of the timeline

### DIFF
--- a/src/script/widgets/TimelinePanel.js
+++ b/src/script/widgets/TimelinePanel.js
@@ -1222,9 +1222,11 @@ gxp.TimelinePanel = Ext.extend(Ext.Panel, {
             url = 'http://www.youtube.com/embed/' + params.v;
             var fid = record.getFeature().fid;
             var id = 'player_' + fid;
-            return header + '<br/>' + '<iframe id="' + id + '" type="text/html" width="'+width+'" height="'+height+'" ' +
-                'src="' + url + '?enablejsapi=1&origin='+ window.location.origin + 
-                '" frameborder="0"></iframe>' + '<br/>' + footer;
+            return header + '<br/>' + '<iframe id="' + id + 
+                '" type="text/html" width="' + width + '" height="' + 
+                height + '" ' + 'src="' + url + '?enablejsapi=1&origin=' + 
+                window.location.origin + '" frameborder="0"></iframe>' + 
+                '<br/>' + footer;
         } else {
             return content;
         }


### PR DESCRIPTION
This uses the https://developers.google.com/youtube/iframe_api_reference

When the playback toolbar is playing, and the popup with the youtube video gets displayed, the video starts playing and the playback stops/pauses until the video finishes.

Syntax for embedding the Youtube video is based on: http://en.support.wordpress.com/videos/youtube/

Example usage in the description field:

[youtube=http://www.youtube.com/watch?v=O_s3EryiL7M&w=350] 
