### PR TITLE
cannot specify listeners in outputConfig of layertree plugin

### DIFF
--- a/src/script/plugins/AddLayers.js
+++ b/src/script/plugins/AddLayers.js
@@ -315,26 +315,26 @@ gxp.plugins.AddLayers = Ext.extend(gxp.plugins.Tool, {
             width: 315,
             selectedSource: selectedSource,
             xtype: 'gxp_cataloguesearchpanel',
-            map: this.target.mapPanel.map,
-            listeners: {
-                'addlayer': function(cmp, sourceKey, layerConfig) {
-                    var source = this.target.layerSources[sourceKey];
-                    var bounds = OpenLayers.Bounds.fromArray(layerConfig.bbox);
-                    var mapProjection = this.target.mapPanel.map.getProjection();
-                    var bbox = bounds.transform(layerConfig.srs, mapProjection);
-                    layerConfig.srs = mapProjection;
-                    layerConfig.bbox = bbox.toArray();
-                    layerConfig.source = this.initialConfig.catalogSourceKey !== null ? 
-                        this.initialConfig.catalogSourceKey : sourceKey;
-                    var record = source.createLayerRecord(layerConfig);
-                    this.target.mapPanel.layers.add(record);
-                    if (bbox) {
-                        this.target.mapPanel.map.zoomToExtent(bbox);
-                    }
-                },
-                scope: this
-            }
+            map: this.target.mapPanel.map
         }]);
+        output.on({
+            'addlayer': function(cmp, sourceKey, layerConfig) {
+                var source = this.target.layerSources[sourceKey];
+                var bounds = OpenLayers.Bounds.fromArray(layerConfig.bbox);
+                var mapProjection = this.target.mapPanel.map.getProjection();
+                var bbox = bounds.transform(layerConfig.srs, mapProjection);
+                layerConfig.srs = mapProjection;
+                layerConfig.bbox = bbox.toArray();
+                layerConfig.source = this.initialConfig.catalogSourceKey !== null ?
+                    this.initialConfig.catalogSourceKey : sourceKey;
+                var record = source.createLayerRecord(layerConfig);
+                this.target.mapPanel.layers.add(record);
+                if (bbox) {
+                    this.target.mapPanel.map.zoomToExtent(bbox);
+                }
+            },
+            scope: this
+        });
         var popup = output.findParentByType('window');
         popup && popup.center();
         return output;

--- a/src/script/plugins/FeatureEditor.js
+++ b/src/script/plugins/FeatureEditor.js
@@ -462,135 +462,135 @@ gxp.plugins.FeatureEditor = Ext.extend(gxp.plugins.ClickableFeatures, {
                         schema: this.schema,
                         allowDelete: true,
                         width: 200,
-                        height: 250,
-                        listeners: {
-                            "close": function() {
-                                if (this.readOnly === false) {
-                                    this.selectControl.activate();
+                        height: 250
+                    });
+                    popup.on({
+                        "close": function() {
+                            if (this.readOnly === false) {
+                                this.selectControl.activate();
+                            }
+                            if(feature.layer && feature.layer.selectedFeatures.indexOf(feature) !== -1) {
+                                this.selectControl.unselect(feature);
+                            }
+                            if (feature === this.autoLoadedFeature) {
+                                if (feature.layer) {
+                                    feature.layer.removeFeatures([evt.feature]);
                                 }
-                                if(feature.layer && feature.layer.selectedFeatures.indexOf(feature) !== -1) {
-                                    this.selectControl.unselect(feature);
-                                }
-                                if (feature === this.autoLoadedFeature) {
-                                    if (feature.layer) {
-                                        feature.layer.removeFeatures([evt.feature]);
-                                    }
-                                    this.autoLoadedFeature = null;
-                                }
-                            },
-                            "featuremodified": function(popup, feature) {
-                                featureStore.on({
-                                    beforewrite: {
-                                        fn: function(store, action, rs, options) {
-                                            if (this.commitMessage === true) {
-                                                options.params.handle = this._commitMsg;
-                                                delete this._commitMsg;
-                                            }
-                                        },
-                                        single: true
+                                this.autoLoadedFeature = null;
+                            }
+                        },
+                        "featuremodified": function(popup, feature) {
+                            featureStore.on({
+                                beforewrite: {
+                                    fn: function(store, action, rs, options) {
+                                        if (this.commitMessage === true) {
+                                            options.params.handle = this._commitMsg;
+                                            delete this._commitMsg;
+                                        }
                                     },
-                                    beforesave: {
-                                        fn: function() {
-                                            if (popup && popup.isVisible()) {
-                                                popup.disable();
+                                    single: true
+                                },
+                                beforesave: {
+                                    fn: function() {
+                                        if (popup && popup.isVisible()) {
+                                            popup.disable();
+                                        }
+                                        if (this.commitMessage === true) {
+                                            if (!this._commitMsg) {
+                                                var fn = arguments.callee;
+                                                Ext.Msg.show({
+                                                    prompt: true,
+                                                    title: this.commitTitle,
+                                                    msg: this.commitText,
+                                                    buttons: Ext.Msg.OK,
+                                                    fn: function(btn, text) {
+                                                        if (btn === 'ok') {
+                                                            this._commitMsg = text;
+                                                            featureStore.un('beforesave', fn, this);
+                                                            featureStore.save();
+                                                        }
+                                                    },
+                                                    scope: this,
+                                                    multiline: true
+                                                });
+                                                return false;
                                             }
-                                            if (this.commitMessage === true) {
-                                                if (!this._commitMsg) {
-                                                    var fn = arguments.callee;
-                                                    Ext.Msg.show({
-                                                        prompt: true,
-                                                        title: this.commitTitle,
-                                                        msg: this.commitText,
-                                                        buttons: Ext.Msg.OK,
-                                                        fn: function(btn, text) {
-                                                            if (btn === 'ok') {
-                                                                this._commitMsg = text;
-                                                                featureStore.un('beforesave', fn, this);
-                                                                featureStore.save();
-                                                            }
-                                                        },
-                                                        scope: this,
-                                                        multiline: true
-                                                    });
-                                                    return false;
-                                                }
-                                            }
-                                        },
-                                        single: this.commitMessage !== true
+                                        }
                                     },
-                                    write: {
-                                        fn: function() {
-                                            if (popup) {
-                                                if (popup.isVisible()) {
-                                                    popup.enable();
-                                                }
-                                                if (this.closeOnSave) {
-                                                    popup.close();
-                                                }
-                                            }
-                                            var layer = featureManager.layerRecord;
-                                            this.target.fireEvent("featureedit", featureManager, {
-                                                name: layer.get("name"),
-                                                source: layer.get("source")
-                                            });
-                                        },
-                                        single: true
-                                    },
-                                    exception: {
-                                        fn: function(proxy, type, action, options, response, records) {
-                                            var msg = this.exceptionText;
-                                            if (type === "remote") {
-                                                // response is service exception
-                                                if (response.exceptionReport) {
-                                                    msg = gxp.util.getOGCExceptionText(response.exceptionReport);
-                                                }
-                                            } else {
-                                                // non-200 response from server
-                                                msg = "Status: " + response.status;
-                                            }
-                                            // fire an event on the feature manager
-                                            featureManager.fireEvent("exception", featureManager, 
-                                                response.exceptionReport || {}, msg, records);
-                                            // only show dialog if there is no listener registered
-                                            if (featureManager.hasListener("exception") === false && 
-                                                featureStore.hasListener("exception") === false) {
-                                                    Ext.Msg.show({
-                                                        title: this.exceptionTitle,
-                                                        msg: msg,
-                                                        icon: Ext.MessageBox.ERROR,
-                                                        buttons: {ok: true}
-                                                    });
-                                            }
-                                            if (popup && popup.isVisible()) {
+                                    single: this.commitMessage !== true
+                                },
+                                write: {
+                                    fn: function() {
+                                        if (popup) {
+                                            if (popup.isVisible()) {
                                                 popup.enable();
-                                                popup.startEditing();
                                             }
-                                        },
-                                        single: true
+                                            if (this.closeOnSave) {
+                                                popup.close();
+                                            }
+                                        }
+                                        var layer = featureManager.layerRecord;
+                                        this.target.fireEvent("featureedit", featureManager, {
+                                            name: layer.get("name"),
+                                            source: layer.get("source")
+                                        });
                                     },
-                                    scope: this
-                                });                                
-                                if(feature.state === OpenLayers.State.DELETE) {
-                                    /**
-                                     * If the feature state is delete, we need to
-                                     * remove it from the store (so it is collected
-                                     * in the store.removed list.  However, it should
-                                     * not be removed from the layer.  Until
-                                     * http://trac.geoext.org/ticket/141 is addressed
-                                     * we need to stop the store from removing the
-                                     * feature from the layer.
-                                     */
-                                    featureStore._removing = true; // TODO: remove after http://trac.geoext.org/ticket/141
-                                    featureStore.remove(featureStore.getRecordFromFeature(feature));
-                                    delete featureStore._removing; // TODO: remove after http://trac.geoext.org/ticket/141
-                                }
-                                featureStore.save();
-                            },
-                            "canceledit": function(popup, feature) {
-                                featureStore.commitChanges();
-                            },
-                            scope: this
-                        }
+                                    single: true
+                                },
+                                exception: {
+                                    fn: function(proxy, type, action, options, response, records) {
+                                        var msg = this.exceptionText;
+                                        if (type === "remote") {
+                                            // response is service exception
+                                            if (response.exceptionReport) {
+                                                msg = gxp.util.getOGCExceptionText(response.exceptionReport);
+                                            }
+                                        } else {
+                                            // non-200 response from server
+                                            msg = "Status: " + response.status;
+                                        }
+                                        // fire an event on the feature manager
+                                        featureManager.fireEvent("exception", featureManager, 
+                                            response.exceptionReport || {}, msg, records);
+                                        // only show dialog if there is no listener registered
+                                        if (featureManager.hasListener("exception") === false && 
+                                            featureStore.hasListener("exception") === false) {
+                                                Ext.Msg.show({
+                                                    title: this.exceptionTitle,
+                                                    msg: msg,
+                                                    icon: Ext.MessageBox.ERROR,
+                                                    buttons: {ok: true}
+                                                });
+                                        }
+                                        if (popup && popup.isVisible()) {
+                                            popup.enable();
+                                            popup.startEditing();
+                                        }
+                                    },
+                                    single: true
+                                },
+                                scope: this
+                            });                                
+                            if(feature.state === OpenLayers.State.DELETE) {
+                                /**
+                                 * If the feature state is delete, we need to
+                                 * remove it from the store (so it is collected
+                                 * in the store.removed list.  However, it should
+                                 * not be removed from the layer.  Until
+                                 * http://trac.geoext.org/ticket/141 is addressed
+                                 * we need to stop the store from removing the
+                                 * feature from the layer.
+                                 */
+                                featureStore._removing = true; // TODO: remove after http://trac.geoext.org/ticket/141
+                                featureStore.remove(featureStore.getRecordFromFeature(feature));
+                                delete featureStore._removing; // TODO: remove after http://trac.geoext.org/ticket/141
+                            }
+                            featureStore.save();
+                        },
+                        "canceledit": function(popup, feature) {
+                            featureStore.commitChanges();
+                        },
+                        scope: this
                     });
                     this.popup = popup;
                 }

--- a/src/script/plugins/FeatureGrid.js
+++ b/src/script/plugins/FeatureGrid.js
@@ -246,49 +246,48 @@ gxp.plugins.FeatureGrid = Ext.extend(gxp.plugins.ClickableFeatures, {
                 },
                 scope: this
             }] : [])),
-            listeners: {
-                "added": function(cmp, ownerCt) {
-                    function onClear() {
-                        this.displayTotalResults();
-                        this.selectOnMap && this.selectControl.deactivate();
-                        this.autoCollapse && typeof ownerCt.collapse == "function" &&
-                            ownerCt.collapse();
-                    }
-                    function onPopulate() {
-                        this.displayTotalResults();
-                        this.selectOnMap && this.selectControl.activate();
-                        this.autoExpand && typeof ownerCt.expand == "function" &&
-                            ownerCt.expand();
-                    }
-                    featureManager.on({
-                        "query": function(tool, store) {
-                            if (store && store.getCount()) {
-                                onPopulate.call(this);
-                            } else {
-                                onClear.call(this);
-                            }
-                        },
-                        "layerchange": onClear,
-                        "clearfeatures": onClear,
-                        scope: this
-                    });
-                },
-                contextmenu: function(event) {
-                    if (featureGrid.contextMenu.items.getCount() > 0) {
-                        var rowIndex = featureGrid.getView().findRowIndex(event.getTarget());
-                        if (rowIndex !== false) {
-                            featureGrid.getSelectionModel().selectRow(rowIndex);
-                            featureGrid.contextMenu.showAt(event.getXY());
-                            event.stopEvent();
-                        }
-                    }
-                },
-                scope: this
-            },
             contextMenu: new Ext.menu.Menu({items: []})
         }, config || {});
         var featureGrid = gxp.plugins.FeatureGrid.superclass.addOutput.call(this, config);
-        
+        featureGrid.on({
+            "added": function(cmp, ownerCt) {
+                function onClear() {
+                    this.displayTotalResults();
+                    this.selectOnMap && this.selectControl.deactivate();
+                    this.autoCollapse && typeof ownerCt.collapse == "function" &&
+                        ownerCt.collapse();
+                }
+                function onPopulate() {
+                    this.displayTotalResults();
+                    this.selectOnMap && this.selectControl.activate();
+                    this.autoExpand && typeof ownerCt.expand == "function" &&
+                        ownerCt.expand();
+                }
+                featureManager.on({
+                    "query": function(tool, store) {
+                        if (store && store.getCount()) {
+                            onPopulate.call(this);
+                        } else {
+                            onClear.call(this);
+                        }
+                    },
+                    "layerchange": onClear,
+                    "clearfeatures": onClear,
+                    scope: this
+                });
+            },
+            contextmenu: function(event) {
+                if (featureGrid.contextMenu.items.getCount() > 0) {
+                    var rowIndex = featureGrid.getView().findRowIndex(event.getTarget());
+                    if (rowIndex !== false) {
+                        featureGrid.getSelectionModel().selectRow(rowIndex);
+                        featureGrid.contextMenu.showAt(event.getXY());
+                        event.stopEvent();
+                    }
+                }
+            },
+            scope: this
+        });
         if (this.alwaysDisplayOnMap || (this.selectOnMap === true && this.displayMode === "selected")) {
             featureManager.showLayer(this.id, this.displayMode);
         }        

--- a/src/script/plugins/LayerProperties.js
+++ b/src/script/plugins/LayerProperties.js
@@ -102,7 +102,7 @@ gxp.plugins.LayerProperties = Ext.extend(gxp.plugins.Tool, {
         if (panelConfig && panelConfig[xtype]) {
             Ext.apply(config, panelConfig[xtype]);
         }
-        return gxp.plugins.LayerProperties.superclass.addOutput.call(this, Ext.apply({
+        var output = gxp.plugins.LayerProperties.superclass.addOutput.call(this, Ext.apply({
             xtype: xtype,
             authorized: this.target.isAuthorized(),
             layerRecord: record,
@@ -110,18 +110,19 @@ gxp.plugins.LayerProperties = Ext.extend(gxp.plugins.Tool, {
             defaults: {
                 style: "padding: 10px",
                 autoHeight: this.outputConfig.autoHeight
-            },
-            listeners: {
-                added: function(cmp) {
-                    if (!this.outputTarget) {
-                        cmp.on("afterrender", function() {
-                            cmp.ownerCt.ownerCt.center();
-                        }, this, {single: true});
-                    }
-                },
-                scope: this
             }
         }, config));
+        output.on({
+            added: function(cmp) {
+                if (!this.outputTarget) {
+                    cmp.on("afterrender", function() {
+                        cmp.ownerCt.ownerCt.center();
+                    }, this, {single: true});
+                }
+            },
+            scope: this
+        });
+        return output;
     }
         
 });

--- a/src/script/plugins/LayerTree.js
+++ b/src/script/plugins/LayerTree.js
@@ -119,7 +119,13 @@ gxp.plugins.LayerTree = Ext.extend(gxp.plugins.Tool, {
      */
     addOutput: function(config) {
         config = Ext.apply(this.createOutputConfig(), config || {});
-        return gxp.plugins.LayerTree.superclass.addOutput.call(this, config);
+        var output = gxp.plugins.LayerTree.superclass.addOutput.call(this, config);
+        output.on({
+            contextmenu: this.handleTreeContextMenu,
+            beforemovenode: this.handleBeforeMoveNode,
+            scope: this
+        });
+        return output;
     },
     
     /** private: method[createOutputConfig]
@@ -190,11 +196,6 @@ gxp.plugins.LayerTree = Ext.extend(gxp.plugins.Tool, {
                     scope: this
                 }
             }),
-            listeners: {
-                contextmenu: this.handleTreeContextMenu,
-                beforemovenode: this.handleBeforeMoveNode,                
-                scope: this
-            },
             contextMenu: new Ext.menu.Menu({
                 items: []
             })

--- a/src/script/plugins/WMSGetFeatureInfo.js
+++ b/src/script/plugins/WMSGetFeatureInfo.js
@@ -216,15 +216,15 @@ gxp.plugins.WMSGetFeatureInfo = Ext.extend(gxp.plugins.Tool, {
                     autoHeight: true,
                     autoWidth: true,
                     collapsible: true
-                },
-                listeners: {
-                    close: (function(key) {
-                        return function(panel){
-                            delete this.popupCache[key];
-                        };
-                    })(popupKey),
-                    scope: this
                 }
+            });
+            popup.on({                    
+                close: (function(key) {
+                    return function(panel){
+                        delete this.popupCache[key];
+                    };
+                })(popupKey),
+                scope: this
             });
             this.popupCache[popupKey] = popup;
         } else {


### PR DESCRIPTION
since this will override the listeners that the code in the layertree plugin is creating:

```
            listeners: {
                contextmenu: this.handleTreeContextMenu,
                beforemovenode: this.handleBeforeMoveNode,
                scope: this
            },
```

```

                ptype: "gxp_layertree",
                outputConfig: {
                    id: "layertree",
                    enableDD:true,
                    listeners: {
                        'nodedrop': function(evt) {
                            ..
                        },
                        scope: this
                    }
                },
                outputTarget: "tree"
```
