### PR TITLE
Properly set equivalent projection when possible in WMSSource

### DIFF
--- a/src/script/plugins/WMSSource.js
+++ b/src/script/plugins/WMSSource.js
@@ -488,11 +488,15 @@ gxp.plugins.WMSSource = Ext.extend(gxp.plugins.LayerSource, {
             // compatible projection that equals the map projection. This helps
             // us in dealing with the different EPSG codes for web mercator.
             var layerProjection = this.getProjection(original);
+            if (layerProjection) {
+                layer.addOptions({projection: layerProjection});
+            }
 
             var projCode = (layerProjection || projection).getCode(),
                 bbox = original.get("bbox"), maxExtent;
+
+            // determine maxExtent in map projection
             if (bbox && bbox[projCode]){
-                layer.addOptions({projection: layerProjection});
                 maxExtent = OpenLayers.Bounds.fromArray(bbox[projCode].bbox, layer.reverseAxisOrder());
             } else {
                 var llbbox = original.get("llbbox");

--- a/tests/script/plugins/WMSSource.html
+++ b/tests/script/plugins/WMSSource.html
@@ -93,6 +93,49 @@
             });
         }
 
+        function test_createLayerRecord_102113(t) {
+
+            /**
+                This test confirms that when a viewer is configured with
+                EPSG:102113 but the server doesn't advertise the same, the
+                layer projection will be set to an equivalent projection.
+             */
+
+            t.plan(1);
+
+            var viewer = new gxp.Viewer({
+                sources: {
+                    local: {
+                        ptype: "gxp_wmssource",
+                        url: "wms_caps.xml"
+                    }
+                },
+                map: {
+                    projection: "EPSG:102113",
+                    center: [0, 0],
+                    zoom: 1,
+                    layers: [{
+                        source: "local",
+                        name: "usa:states"
+                    }]
+                }
+            });
+
+
+            t.delay_call(1, function() {
+                var source = viewer.layerSources.local,
+                    record = source.createLayerRecord({name: "world:borders"}),
+                    projection = record.getLayer().projection;
+
+                if (projection) {
+                    var code = projection.getCode();
+                    t.ok(code === 'EPSG:900913' || code === 'EPSG:3857', 'mercator');
+                } else {
+                    t.fail('layer has no projection')
+                }
+            });
+        }
+
         function test_createLayerRecord_restUrl(t) {
             t.plan(1);
 

--- a/tests/script/plugins/wms_caps.xml
+++ b/tests/script/plugins/wms_caps.xml
@@ -145,8 +145,6 @@
       <SRS>EPSG:4326</SRS>
       <SRS>EPSG:900913</SRS>
       <SRS>EPSG:3857</SRS>
-      <SRS>EPSG:102113</SRS>
-      <SRS>EPSG:102100</SRS>
       <LatLonBoundingBox minx="-180.0" miny="-157.323" maxx="180.0" maxy="90.0"/>
       <Layer queryable="1">
         <Name>medford:bikelanes</Name>


### PR DESCRIPTION
If a viewer is configured with 'EPSG:102113' and the server advertises an equivalent projection (e.g. 'EPSG:3857' or 'EPSG:900913') but doesn't provide a bbox in the equivalent projection, we fail to set the layer projection.
