### PR TITLE
Check for the filters property before using

### DIFF
--- a/src/script/plugins/GeoNodeCatalogueSource.js
+++ b/src/script/plugins/GeoNodeCatalogueSource.js
@@ -129,7 +129,6 @@ gxp.plugins.GeoNodeCatalogueSource = Ext.extend(gxp.plugins.CatalogueSource, {
                 }
             }
         }
-
         Ext.apply(this.store.baseParams, {
             'q': options.queryString,
             'limit': options.limit


### PR DESCRIPTION
In the GeoNOde Catalog Source filter method the filters property
should be an optional argument. This commit checks to make sure it
exits before using it. Should not change existing functionality.
