### PR TITLE
Put the source combo box into a Ext.container

### DIFF
--- a/src/script/plugins/AddLayers.js
+++ b/src/script/plugins/AddLayers.js
@@ -533,7 +533,7 @@ gxp.plugins.AddLayers = Ext.extend(gxp.plugins.Tool, {
 
         if (this.target.proxy || data.length > 1) {
             container = new Ext.Container({
-                cls: 'addLayerSearchContainer',
+                cls: 'gxp-addlayers-sourceselect',
                 items: [
                     new Ext.Toolbar.TextItem({text: this.layerSelectionText}),
                     sourceComboBox


### PR DESCRIPTION
In the AddLayers widget, we would like to turn off the ability for
users to search for a source. This commit puts both the test and the
combo box into an ext.container which then allows use to turn it off
via CSS
