### PR TITLE
handle getState when layers contains Openlayers.layer.Vector

### DIFF
--- a/src/script/widgets/Viewer.js
+++ b/src/script/widgets/Viewer.js
@@ -717,11 +717,11 @@ gxp.Viewer = Ext.extend(Ext.util.Observable, {
         var sources = {};
         this.mapPanel.layers.each(function(record){
             var layer = record.getLayer();
-            if (layer.displayInLayerSwitcher) {
+            if (layer.displayInLayerSwitcher && !(layer instanceof OpenLayers.Layer.Vector) ) {
                 var id = record.get("source");
                 var source = this.layerSources[id];
                 if (!source) {
-                    throw new Error("Could not find source for layer '" + record.get("name") + "'");
+                    throw new Error("Could not find source for record '" + record.get("name") + " and layer " + layer.name + "'");
                 }
                 // add layer
                 state.map.layers.push(source.getConfigForRecord(record));


### PR DESCRIPTION
Make more verbose error message, and skip getting state of layer if instanceof Openlayers.Layer.Vector since it has no source.
