### PR TITLE
Fix fill opacity in fill symbolizer

### DIFF
--- a/src/script/widgets/FillSymbolizer.js
+++ b/src/script/widgets/FillSymbolizer.js
@@ -87,7 +87,7 @@ gxp.FillSymbolizer = Ext.extend(Ext.FormPanel, {
 
         var sliderValue = 100;
         if (this.opacityProperty in this.symbolizer) {
-            sliderValue = this.symbolizer[this.opacityProperty];
+            sliderValue = this.symbolizer[this.opacityProperty]*100;
         }
         else if (OpenLayers.Renderer.defaultSymbolizer[this.opacityProperty]) {
             sliderValue = OpenLayers.Renderer.defaultSymbolizer[this.opacityProperty]*100;


### PR DESCRIPTION
When you edit a layer style that contains fillOpacity property saved, the slider shows always '1 %'.

This change fix this problem with \* 100.
