### PR TITLE
Adds Google to printable layers.

### DIFF
--- a/src/script/plugins/Print.js
+++ b/src/script/plugins/Print.js
@@ -239,7 +239,8 @@ gxp.plugins.Print = Ext.extend(gxp.plugins.Tool, {
             function isPrintable(layer) {
                 return layer.getVisibility() === true && (
                     layer instanceof OpenLayers.Layer.WMS ||
-                    layer instanceof OpenLayers.Layer.OSM
+                    layer instanceof OpenLayers.Layer.OSM ||
+                    layer instanceof OpenLayers.Layer.Google
                 );
             }
 


### PR DESCRIPTION
Enables printing (PDF) maps with Google background layers (tested with custom OpenGeo Suite 3 app).
Requires [Google PrintProvider](https://github.com/cspanring/geoext/commit/8f25038b02cfea34317c3d2bbeef7dac3e835893) to be fully functional.
