### PR TITLE
make sure the initial hidden state of the legend component matches the v...

### DIFF
--- a/src/script/plugins/LayerManager.js
+++ b/src/script/plugins/LayerManager.js
@@ -112,6 +112,7 @@ gxp.plugins.LayerManager = Ext.extend(gxp.plugins.LayerTree, {
                     // TODO these baseParams were only tested with GeoServer,
                     // so maybe they should be configurable - and they are
                     // only relevant for gx_wmslegend.
+                    hidden: !attr.layer.getVisibility(),
                     baseParams: Ext.apply({
                         transparent: true,
                         format: "image/png",


### PR DESCRIPTION
...isibility of the layer, this will prevent legends showing up after drag and drop even if the layer itself is not visible
