### PR TITLE
RangeSliderTip.js file missing

### DIFF
--- a/src/script/loader.js
+++ b/src/script/loader.js
@@ -54,7 +54,6 @@
         "widgets/form/PlaybackModeComboBox.js",
         "widgets/PlaybackOptionsPanel.js",
         "widgets/slider/ClassBreakSlider.js",
-        "widgets/tips/RangeSliderTip.js",
         "widgets/TimelinePanel.js",
         "widgets/form/CSWFilterField.js",
         "widgets/CatalogueSearchPanel.js",


### PR DESCRIPTION
The file required at  https://github.com/boundlessgeo/gxp/blob/master/src/script/loader.js#L57
doesn't seem to exist in the files tree.
See https://github.com/boundlessgeo/gxp/tree/master/src/script/widgets/tips
