### PR TITLE
add a beforecreateportal event to gxp.Viewer

### DIFF
--- a/src/script/widgets/Viewer.js
+++ b/src/script/widgets/Viewer.js
@@ -231,6 +231,11 @@ gxp.Viewer = Ext.extend(Ext.util.Observable, {
              *  Fires when application is ready for user interaction.
              */
             "ready",
+
+            /** api: event[beforecreateportal]
+             *  Fires before the portal is created by the Ext ComponentManager.
+             */
+            "beforecreateportal",
             
             /** api: event[portalready]
              *  Fires after the portal is initialized.
@@ -551,6 +556,8 @@ gxp.Viewer = Ext.extend(Ext.util.Observable, {
             this.mapPanel.region = "center";
             this.portalItems.push(this.mapPanel);
         }
+
+        this.fireEvent("beforecreateportal");
         
         this.portal = Ext.ComponentMgr.create(Ext.applyIf(config, {
             layout: "fit",


### PR DESCRIPTION
This will allow applications to change this.portalItems before the portal is actually created.

This was done to have the Mareano application inherit from GeoExplorer without having to copy a lot of the GeoExplorer code of the initPortal function.
