### PR TITLE
Make layers added through CS-W queryable by default

### DIFF
--- a/src/script/plugins/CSWCatalogueSource.js
+++ b/src/script/plugins/CSWCatalogueSource.js
@@ -142,6 +142,11 @@ gxp.plugins.CSWCatalogueSource = Ext.extend(gxp.plugins.CatalogueSource, {
         }
         Ext.apply(this.store.baseParams, data);
         this.store.load();
+    },
+
+    createLayerRecord: function(layerConfig) {
+        layerConfig.queryable = true;
+        return gxp.plugins.CSWCatalogueSource.superclass.createLayerRecord.apply(this, arguments);
     }
 
 });


### PR DESCRIPTION
Otherwise they cannot be used by the Identify tool.
