### PR TITLE
getState must check that layer is not a marker

### DIFF
--- a/src/script/widgets/Viewer.js
+++ b/src/script/widgets/Viewer.js
@@ -724,7 +724,8 @@ gxp.Viewer = Ext.extend(Ext.util.Observable, {
         var sources = {};
         this.mapPanel.layers.each(function(record){
             var layer = record.getLayer();
-            if (layer.displayInLayerSwitcher && !(layer instanceof OpenLayers.Layer.Vector) ) {
+            if (layer.displayInLayerSwitcher && !(layer instanceof OpenLayers.Layer.Vector)
+				&& !(layer instanceof OpenLayers.Layer.Markers)) {
                 var id = record.get("source");
                 var source = this.layerSources[id];
                 if (!source) {


### PR DESCRIPTION
have getState check that layer is not a marker else getState throws an error - and e.g. save in geoexplorer fails.