### PR TITLE
dont throw error in getState()

### DIFF
--- a/src/script/widgets/Viewer.js
+++ b/src/script/widgets/Viewer.js
@@ -724,7 +724,8 @@ gxp.Viewer = Ext.extend(Ext.util.Observable, {
         var sources = {};
         this.mapPanel.layers.each(function(record){
             var layer = record.getLayer();
-            if (layer.displayInLayerSwitcher && !(layer instanceof OpenLayers.Layer.Vector) ) {
+            if (layer.displayInLayerSwitcher && !(layer instanceof OpenLayers.Layer.Vector)
+				&& !(layer instanceof OpenLayers.Layer.Markers)) {
                 var id = record.get("source");
                 var source = this.layerSources[id];
                 if (!source) {

--- a/src/script/widgets/Viewer.js
+++ b/src/script/widgets/Viewer.js
@@ -724,13 +724,15 @@ gxp.Viewer = Ext.extend(Ext.util.Observable, {
         var sources = {};
         this.mapPanel.layers.each(function(record){
             var layer = record.getLayer();
-            if (layer.displayInLayerSwitcher ) {
+            if ( layer.displayInLayerSwitcher ) {
                 var id = record.get("source");
                 var source = this.layerSources[id];
                 if (!source) {
                     // Either the layer has no source (id=null) or this layer has a layerSources which isnt defined 
-                    console.log("Could not find source type (e.g gxp_wmssource) for layer '" + layer.name  + "' and layer id '" + layer.id + "'.");
-                    console.log("Please provide a plugin source if the layer should be included in getState()");
+                    // Provide a plugin source if the layer should be included in getState()
+                    if (window.console) {
+                        console.warn("Could not find source type (e.g gxp_wmssource) for layer '" + layer.name  + "' and layer id '" + layer.id + "'.");
+                    }
                 } else {
                     // add layer
                     state.map.layers.push(source.getConfigForRecord(record));

--- a/src/script/widgets/Viewer.js
+++ b/src/script/widgets/Viewer.js
@@ -724,17 +724,19 @@ gxp.Viewer = Ext.extend(Ext.util.Observable, {
         var sources = {};
         this.mapPanel.layers.each(function(record){
             var layer = record.getLayer();
-            if (layer.displayInLayerSwitcher && !(layer instanceof OpenLayers.Layer.Vector)
-				&& !(layer instanceof OpenLayers.Layer.Markers)) {
+            if (layer.displayInLayerSwitcher ) {
                 var id = record.get("source");
                 var source = this.layerSources[id];
                 if (!source) {
-                    throw new Error("Could not find source for record '" + record.get("name") + " and layer " + layer.name + "'");
-                }
-                // add layer
-                state.map.layers.push(source.getConfigForRecord(record));
-                if (!sources[id]) {
-                    sources[id] = source.getState();
+                    // Either the layer has no source (id=null) or this layer has a layerSources which isnt defined 
+                    console.log("Could not find source type (e.g gxp_wmssource) for layer '" + layer.name  + "' and layer id '" + layer.id + "'.");
+                    console.log("Please provide a plugin source if the layer should be included in getState()");
+                } else {
+                    // add layer
+                    state.map.layers.push(source.getConfigForRecord(record));
+                    if (!sources[id]) {
+                        sources[id] = source.getState();
+                    }
                 }
             }
         }, this);


### PR DESCRIPTION
Just log the layer that either doesnt have source defined or has a source not found in layerSources.

The user should then provide a plugin source or define a source for the layer (or both) - if the layer should be part of the mapPanel state.